### PR TITLE
ajustando o README e path do index.js no docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ USER app
 
 EXPOSE 9000
 
-CMD nodemon -L --watch . index.js
+CMD nodemon -L --watch . ./src/index.js

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Você pode executar o **DeninhoBot** usando Docker e Docker Compose, para isso, 
 3. No diretório raiz do projeto, digite `docker-compose up -d`. Isso vai fazer com que o Docker faça o build do container e coloque em background.
 
 ### Comandos úteis do docker-compose
+- Se fizer mudanças no Dockerfile, execute `docker-compose build` antes do `docker-composer up -d`
 - Se quiser ver os logs, no diretório raiz do projeto digite `docker-compose logs -f`
 - Se quiser parar o bot, digite `docker-compose down`
 


### PR DESCRIPTION
O `index.js` mudou para o diretório `/src`. Fiz o ajuste do path no Docker e atualizei o README com as instruções de build, caso hava mudanças no Dockerfile.